### PR TITLE
Set AutoOpen attribute for the assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+##### 0.5.0 (2018-03-14)
+
+* Breaking: Added assembly-level AutoOpen attribute. Importing the library will automatically import the helper methods as well as the builder instances
+
 ##### 0.4.0 (2018-03-08)
 
 * Breaking: Rename `orElse` and `orElseWith` to `defaultValue` and `defaultWith` so the names match the functions with similar signatures in the `Option` module

--- a/Cvdm.ErrorHandling.Tests/AsyncResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/AsyncResultBuilderTests.fs
@@ -4,7 +4,6 @@ open System
 open Xunit
 open Hedgehog
 open Swensen.Unquote
-open Cvdm.ErrorHandling
 
 /// Helper type for simulating side effects.
 type Trigger() =

--- a/Cvdm.ErrorHandling.Tests/Cvdm.ErrorHandling.Tests.fsproj
+++ b/Cvdm.ErrorHandling.Tests/Cvdm.ErrorHandling.Tests.fsproj
@@ -24,8 +24,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 </ItemGroup>
   
+  <PropertyGroup>
+    <RestoreSources>../Cvdm.ErrorHandling/bin/Debug;https://api.nuget.org/v3/index.json;$(RestoreSources)</RestoreSources>
+  </PropertyGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Cvdm.ErrorHandling\Cvdm.ErrorHandling.fsproj" />
+    <PackageReference Include="Cvdm.ErrorHandling" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/Cvdm.ErrorHandling.Tests/Cvdm.ErrorHandling.Tests.fsproj
+++ b/Cvdm.ErrorHandling.Tests/Cvdm.ErrorHandling.Tests.fsproj
@@ -24,13 +24,9 @@
     <PackageReference Include="xunit.core" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 </ItemGroup>
-  
-  <PropertyGroup>
-    <RestoreSources>../Cvdm.ErrorHandling/bin/Debug;https://api.nuget.org/v3/index.json;$(RestoreSources)</RestoreSources>
-  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cvdm.ErrorHandling" Version="0.5.0" />
+    <ProjectReference Include="..\Cvdm.ErrorHandling\Cvdm.ErrorHandling.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/Cvdm.ErrorHandling.Tests/Cvdm.ErrorHandling.Tests.fsproj
+++ b/Cvdm.ErrorHandling.Tests/Cvdm.ErrorHandling.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="ResultBuilderTests.fs" />
     <Compile Include="AsyncResultBuilderTests.fs" />
     <Compile Include="HelpersTests.fs" />
+    <Compile Include="NamespaceOverride.fs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Cvdm.ErrorHandling.Tests/HelpersTests.fs
+++ b/Cvdm.ErrorHandling.Tests/HelpersTests.fs
@@ -3,7 +3,6 @@
 open Xunit
 open Hedgehog
 open Swensen.Unquote
-open Cvdm.ErrorHandling
 
 module Result =
 

--- a/Cvdm.ErrorHandling.Tests/NamespaceOverride.fs
+++ b/Cvdm.ErrorHandling.Tests/NamespaceOverride.fs
@@ -1,0 +1,17 @@
+/// Testing that the auto-opened name do not collide with user-defined ones
+module SomeUserNamespace.SomeUserModule
+
+module AsyncResult = 
+  let map = ""
+
+module Result = 
+  let map = ""
+
+let result = ""
+let asyncResult = ""
+
+let _ : string = AsyncResult.map
+let _ : string = Result.map
+let _ : string = result
+let _ : string = asyncResult
+

--- a/Cvdm.ErrorHandling.Tests/NamespaceOverride.fs
+++ b/Cvdm.ErrorHandling.Tests/NamespaceOverride.fs
@@ -1,17 +1,24 @@
-/// Testing that the auto-opened name do not collide with user-defined ones
+/// Testing that the auto-opened name do not override any user-defined ones...
 module SomeUserNamespace.SomeUserModule
 
 module AsyncResult = 
-  let map = ""
+  let defaultValue = ""
 
 module Result = 
-  let map = ""
+  let defaultValue = ""
 
 let result = ""
 let asyncResult = ""
 
-let _ : string = AsyncResult.map
-let _ : string = Result.map
+let _ : string = Result.defaultValue
+let _ : string = AsyncResult.defaultValue
 let _ : string = result
 let _ : string = asyncResult
 
+/// ... but that the user may still use the library ones by opening them explicitly
+open Cvdm.ErrorHandling
+
+let _ : 'a -> Async<Result<'a, 'b>> -> Async<'a> = AsyncResult.defaultValue
+let _ : 'a -> Result<'a, 'b> -> 'a = Result.defaultValue
+let _ : ResultBuilder = result
+let _ : AsyncResultBuilder = asyncResult

--- a/Cvdm.ErrorHandling.Tests/NamespaceOverride.fs
+++ b/Cvdm.ErrorHandling.Tests/NamespaceOverride.fs
@@ -1,4 +1,4 @@
-/// Testing that the auto-opened name do not override any user-defined ones...
+// Testing that the auto-opened name do not override any user-defined ones...
 module SomeUserNamespace.SomeUserModule
 
 module AsyncResult = 
@@ -15,7 +15,7 @@ let _ : string = AsyncResult.defaultValue
 let _ : string = result
 let _ : string = asyncResult
 
-/// ... but that the user may still use the library ones by opening them explicitly
+// ... but that the user may still use the library ones by opening them explicitly
 open Cvdm.ErrorHandling
 
 let _ : 'a -> Async<Result<'a, 'b>> -> Async<'a> = AsyncResult.defaultValue

--- a/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
@@ -4,8 +4,6 @@ open System
 open Xunit
 open Hedgehog
 open Swensen.Unquote
-open Cvdm.ErrorHandling
-
 
 [<Fact>]
 let ``return wraps value in Ok`` () =

--- a/Cvdm.ErrorHandling/AssemblyInfo.fs
+++ b/Cvdm.ErrorHandling/AssemblyInfo.fs
@@ -1,0 +1,5 @@
+namespace Cvdm
+
+[<assembly:AutoOpen("Cvdm.ErrorHandling")>]
+
+do()

--- a/Cvdm.ErrorHandling/AsyncResultBuilder.fs
+++ b/Cvdm.ErrorHandling/AsyncResultBuilder.fs
@@ -83,6 +83,3 @@ module Extensions =
 
     member this.Combine (asnc: Async<'a>, binder: 'a -> Async<Result<'b, 'c>>) : Async<Result<'b, 'c>> =
       this.Bind(asnc, binder)
-
-
-let asyncResult = AsyncResultBuilder()

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
@@ -20,12 +20,12 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-  </PropertyGroup>
-
+  </PropertyGroup>  
+  
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ResultBuilder.fs" />
     <Compile Include="AsyncResultBuilder.fs" />
     <Compile Include="Helpers.fs" />
   </ItemGroup>
-
 </Project>

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -20,8 +20,8 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-  </PropertyGroup>  
-  
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ResultBuilder.fs" />

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>Christer van der Meeren</Authors>
     <Description>AsyncResult and Result computation expressions and helper functions for error handling in F#.</Description>
     <PackageLicenseUrl>https://github.com/cmeeren/Cvdm.ErrorHandling/blob/master/LICENSE</PackageLicenseUrl>

--- a/Cvdm.ErrorHandling/Helpers.fs
+++ b/Cvdm.ErrorHandling/Helpers.fs
@@ -1,6 +1,11 @@
 ﻿[<AutoOpen>]
 module Cvdm.ErrorHandling.Helpers
 
+/// A computation expression to build a Result<'ok, 'error> value
+let result = ResultBuilder()
+
+/// A computation expression to build an Async<Result<'ok, 'error>> value
+let asyncResult = AsyncResultBuilder()
 
 let private asyncMap f asnc =
   async {

--- a/Cvdm.ErrorHandling/ResultBuilder.fs
+++ b/Cvdm.ErrorHandling/ResultBuilder.fs
@@ -48,5 +48,3 @@ type ResultBuilder() =
       this.While(enum.MoveNext,
         this.Delay(fun () -> body enum.Current)))
 
-
-let result = ResultBuilder()

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cvdm.ErrorHandling
 
 *`asyncResult` and `result` computation expressions and helper functions for error handling in F#.*
 
-
+* NOTE: this library is tagged with the `AutoOpen` attribute. Referencing this library will automatically open the `Cvdm.ErrorHandling` namespace. This means you will have access to this library's computation expressions and helper methods in every file without any explicit `open` statements.
 
 The `result` computation expression
 ---

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Cvdm.ErrorHandling
 
 *`asyncResult` and `result` computation expressions and helper functions for error handling in F#.*
 
-* NOTE: this library is tagged with the `AutoOpen` attribute. Referencing this library will automatically open the `Cvdm.ErrorHandling` namespace. This means you will have access to this library's computation expressions and helper methods in every file without any explicit `open` statements.
-
 The `result` computation expression
 ---
 
@@ -76,6 +74,12 @@ let login (username: string) (password: string) : Async<Result<AuthToken, LoginE
     return! user |> createAuthToken |> Result.mapError TokenErr
   }
 ```
+
+### A note on namespace imports
+
+This library is tagged with the `AutoOpen` attribute. Referencing this library will automatically open the `Cvdm.ErrorHandling` namespace. This means you will have access to this library's computation expressions and helper methods in every file without any explicit `open` statements.
+
+Should you have a value or function in your code with the same name as a value or function in this library (e.g. `result`/`Result.defaultValue`), your definition will take precedence. You may override this behaviour in a file and use the library's definition by explicitly `open`ing `Cvdm.ErrorHandling` again.
 
 ### A note on type inference
 


### PR DESCRIPTION
I think this is one of the few libraries that would benefit from being automatically opened in every file by every project that reference it. To that end, I've moved the `result` and `asyncResult` values to the `Helpers` namespace and added a global `AutoOpen` attribute in `AssemblyInfo.fs`.

Now if you reference this library in a script or project, you can immediately use `result {}` CEs and helper functions without having to add `open Cvdm.ErrorHandling` in every single file.

I've tested that a user's self-defined `result` values or `Result.xxx` functions will take precedence over the ones from the library (unless the user explicitly imports those files). So this change *shouldn't* break any existing code, although it's technically possible if another imported library had the same `AutoOpen` attribute.