### PR TITLE
Work property with non-nullable `IDisposable`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ##### 0.5.1 (2018-03-14)
 
-* Fix `use!` in conjunction with non-nullable `IDisposable` types
+* Fix `use`/`use!` in conjunction with non-nullable `IDisposable` types
 
 ##### 0.5.0 (2018-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+##### 0.5.1 (2018-03-14)
+
+* Fix `use!` in conjunction with non-nullsable `IDisposable` types
+
 ##### 0.5.0 (2018-03-14)
 
 * Breaking: Added assembly-level AutoOpen attribute. Importing the library will automatically import the helper methods as well as the builder instances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ##### 0.5.1 (2018-03-14)
 
-* Fix `use!` in conjunction with non-nullsable `IDisposable` types
+* Fix `use!` in conjunction with non-nullable `IDisposable` types
 
 ##### 0.5.0 (2018-03-14)
 

--- a/Cvdm.ErrorHandling.Tests/AsyncResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/AsyncResultBuilderTests.fs
@@ -1061,3 +1061,14 @@ let ``use! ignores null async-wrapped disposable`` () =
       } |> Async.RunSynchronously
     test <@ result = Ok () @>
   }
+
+[<Fact>]
+let ``use! handles non-nullable async-wrapped disposable`` () =
+  Property.check <| property {
+    let result =
+      asyncResult {
+        use! _d = async { return (new CustomDisposable()) }
+        do! Ok ()
+      } |> Async.RunSynchronously
+    raises <@ CustomDisposedException @>
+  }

--- a/Cvdm.ErrorHandling.Tests/AsyncResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/AsyncResultBuilderTests.fs
@@ -1065,10 +1065,23 @@ let ``use! ignores null async-wrapped disposable`` () =
 [<Fact>]
 let ``use! handles non-nullable async-wrapped disposable`` () =
   Property.check <| property {
-    let result =
-      asyncResult {
-        use! _d = async { return (new CustomDisposable()) }
-        do! Ok ()
-      } |> Async.RunSynchronously
-    raises <@ CustomDisposedException @>
+    raises<CustomDisposedException>
+      <@      
+        asyncResult {
+          use! _d = async { return (new CustomDisposable()) }
+          do! Ok ()
+        } |> Async.RunSynchronously
+      @>
   }
+
+[<Fact>]
+let ``use handles non-nullable async-wrapped disposable`` () =
+  Property.check <| property {
+    raises<CustomDisposedException>
+      <@       
+        asyncResult {
+          use _d = new CustomDisposable()
+          do! Ok ()
+        } |> Async.RunSynchronously
+      @>
+  }  

--- a/Cvdm.ErrorHandling.Tests/Helpers.fs
+++ b/Cvdm.ErrorHandling.Tests/Helpers.fs
@@ -6,3 +6,14 @@ type Trigger() =
   let mutable isTriggered = false
   member __.Trigger () = isTriggered <- true
   member __.Triggered = isTriggered
+
+
+/// Helper types for IDisposable tests
+type CustomDisposedException() = 
+  inherit exn()
+
+
+type CustomDisposable() = 
+  interface System.IDisposable with
+    member __.Dispose() = 
+      raise (CustomDisposedException())

--- a/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
@@ -546,3 +546,14 @@ let ``use! ignores null disposable`` () =
     }
     test <@ result = Ok () @>
   }
+
+
+[<Fact>]
+let ``use! handles non-nullable disposable`` () =
+  Property.check <| property {
+    let result = result {
+      use! _d = Ok (new CustomDisposable())
+      do! Ok ()
+    }    
+    raises <@ CustomDisposedException @>
+  }

--- a/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
@@ -551,19 +551,23 @@ let ``use! ignores null disposable`` () =
 [<Fact>]
 let ``use! handles non-nullable disposable`` () =
   Property.check <| property {
-    let result = result {
-      use! _d = Ok (new CustomDisposable())
-      do! Ok ()
-    }    
-    raises <@ CustomDisposedException @>
+    raises<CustomDisposedException> 
+      <@ 
+        result {
+          use! _d = Ok (new CustomDisposable())
+          do! Ok ()
+        }    
+      @>
   }
 
 [<Fact>]
 let ``use handles non-nullable disposable`` () =
   Property.check <| property {
-    let result = result {
-      use _d = new CustomDisposable()
-      do! Ok ()
-    }    
-    raises <@ CustomDisposedException @>
+    raises<CustomDisposedException> 
+      <@ 
+        result {
+          use _d = new CustomDisposable()
+          do! Ok ()
+        }  
+      @>
   }  

--- a/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
+++ b/Cvdm.ErrorHandling.Tests/ResultBuilderTests.fs
@@ -557,3 +557,13 @@ let ``use! handles non-nullable disposable`` () =
     }    
     raises <@ CustomDisposedException @>
   }
+
+[<Fact>]
+let ``use handles non-nullable disposable`` () =
+  Property.check <| property {
+    let result = result {
+      use _d = new CustomDisposable()
+      do! Ok ()
+    }    
+    raises <@ CustomDisposedException @>
+  }  

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -14,7 +14,7 @@
     <PackageLicenseUrl>https://github.com/cmeeren/Cvdm.ErrorHandling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/cmeeren/Cvdm.ErrorHandling</PackageProjectUrl>
     <PackageTags>f# error-handling computation-expression asyncresult async result</PackageTags>
-    <PackageReleaseNotes>Fix `use!` in conjunction with non-nullable `IDisposable` types</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix `use`/`use!` in conjunction with non-nullable `IDisposable` types</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Christer van der Meeren</Authors>
     <Description>AsyncResult and Result computation expressions and helper functions for error handling in F#.</Description>
     <PackageLicenseUrl>https://github.com/cmeeren/Cvdm.ErrorHandling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/cmeeren/Cvdm.ErrorHandling</PackageProjectUrl>
     <PackageTags>f# error-handling computation-expression asyncresult async result</PackageTags>
-    <PackageReleaseNotes>Breaking change: Added assembly-level AutoOpen attribute. Importing the library will automatically import the helper methods as well as the builder instances.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix `use!` in conjunction with non-nullable `IDisposable` types</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Version>0.5.1</Version>
-    <Authors>Christer van der Meeren</Authors>
+    <Authors>Christer van der Meeren;Stefano Pian</Authors>
     <Description>AsyncResult and Result computation expressions and helper functions for error handling in F#.</Description>
     <PackageLicenseUrl>https://github.com/cmeeren/Cvdm.ErrorHandling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/cmeeren/Cvdm.ErrorHandling</PackageProjectUrl>

--- a/Cvdm.ErrorHandling/ResultBuilder.fs
+++ b/Cvdm.ErrorHandling/ResultBuilder.fs
@@ -35,9 +35,8 @@ type ResultBuilder() =
   member x.Using (disp: #IDisposable, body) =
     let result = fun () -> body disp
     x.TryFinally (result, fun () ->
-      match disp with
-      | null -> ()
-      | d -> d.Dispose ())
+      if not (obj.ReferenceEquals(disp, null)) then
+        disp.Dispose ())
 
   member this.While (guard, body) =
     if not <| guard () then this.Zero()

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Christer van der Meeren
+Copyright 2018 Christer van der Meeren, Stefano Pian
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
If you define a type in F# that implements `IDisposable`, that type will not be nullable.

This will break the `use` expressions from this library, which pattern matches against `null`, and you get the compilation error `The type SomeType does not have 'null' as a proper value`.

The fix in this PR: use `obj.ReferenceEquals(disp, null)` instead. This is equivalent performance-wise, except that you are allowed to compare non-nullable types as well.