### PR TITLE
Make library Fable compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+##### 0.5.2 (2018-07-04)
+
+* Configure fsproj file to include source code in the Nuget package for Fable compatibility.
+
 ##### 0.5.1 (2018-03-14)
 
 * Fix `use`/`use!` in conjunction with non-nullable `IDisposable` types
@@ -31,4 +35,3 @@ Changelog
 ##### 0.1.0 (2018-03-07)
 
 * Initial release
-

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -28,4 +28,9 @@
     <Compile Include="AsyncResultBuilder.fs" />
     <Compile Include="Helpers.fs" />
   </ItemGroup>
+  <!-- Add source files to package -->
+  <ItemGroup>
+    <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
+    <!--<Content Include="src\" PackagePath="fable\src\" />-->
+</ItemGroup>
 </Project>

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <Authors>Christer van der Meeren;Stefano Pian</Authors>
     <Description>AsyncResult and Result computation expressions and helper functions for error handling in F#.</Description>
     <PackageLicenseUrl>https://github.com/cmeeren/Cvdm.ErrorHandling/blob/master/LICENSE</PackageLicenseUrl>

--- a/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
+++ b/Cvdm.ErrorHandling/Cvdm.ErrorHandling.fsproj
@@ -14,7 +14,7 @@
     <PackageLicenseUrl>https://github.com/cmeeren/Cvdm.ErrorHandling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/cmeeren/Cvdm.ErrorHandling</PackageProjectUrl>
     <PackageTags>f# error-handling computation-expression asyncresult async result</PackageTags>
-    <PackageReleaseNotes>Fix `use`/`use!` in conjunction with non-nullable `IDisposable` types</PackageReleaseNotes>
+    <PackageReleaseNotes>Make package usable from Fable</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -28,9 +28,10 @@
     <Compile Include="AsyncResultBuilder.fs" />
     <Compile Include="Helpers.fs" />
   </ItemGroup>
-  <!-- Add source files to package -->
+
+  <!-- Add source files to package for Fable compatibility -->
   <ItemGroup>
     <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
-    <!--<Content Include="src\" PackagePath="fable\src\" />-->
-</ItemGroup>
+  </ItemGroup>
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ let login (username: string) (password: string) : Result<AuthToken, LoginError> 
   result {
     // requireSome unwraps a Some value or gives the specified error if None
     let! user = username |> tryGetUser |> Result.requireSome InvalidUser
-    
+
     // requireTrue gives the specified error if false
     do! user |> isPwdValid password |> Result.requireTrue InvalidPwd
-    
+
     // Error value is wrapped/transformed (Unauthorized has signature AuthError -> LoginError)
     do! user |> authorize |> Result.mapError Unauthorized
 
@@ -104,6 +104,10 @@ let! (str: string) = asyncResult { return "" }
 ```
 
 Things seem to work fine when the right-hand side is `Async<_>` or `Result<_,_>`.
+
+### Using this library in a Fable project
+
+This library includes its source code in the Nuget package and has no further dependencies so it can be used with the [Fable](http://fable.io) F# to Javascript transpiler. In Fable projects, module-wide AutoOpen instructions as used by this libary can fail - in this case just add an explicit open statement (`open Cvdm.ErrorHandling`).
 
 ### A technical note on overload resolution
 


### PR DESCRIPTION
As discussed in #7 this library could be used in F# Fable projects (transpilation to javascript). This PR adds the required configuration (modify fsproj file to include fs source code and the .fsproj file itself in the nuget package) and bumps the version number to 0.5.2